### PR TITLE
Changed spacing from 5 mu to word-spacing like book

### DIFF
--- a/while.sty
+++ b/while.sty
@@ -9,37 +9,37 @@
 
 %Adds a protect ... end around a statement.
 \newcommand{\wProtect}[1]{%
-    \mathtt{protect} \; {#1} \; \mathtt{end} \;
+    \mathtt{protect} \  {#1} \  \mathtt{end} \ 
 }
 
 %Adds a protected ... end around a statement. 
 \newcommand{\wProtected}[1]{%
-    \mathtt{protected} \; {#1} \; \mathtt{end} \;
+    \mathtt{protected} \  {#1} \  \mathtt{end} \ 
 }
 
 \newcommand{\wPar}[2]{%
-  {#1} \; \mathtt{par} \; {#2} \;
+  {#1} \  \mathtt{par} \  {#2} \ 
 }
 
 \newcommand{\wIfElse}[3]{%
-    \mathtt{if} \; {#1} \; \mathtt{then} \; {#2} \; \mathtt{else} \; {#3} \; 
+    \mathtt{if} \  {#1} \  \mathtt{then} \  {#2} \  \mathtt{else} \  {#3} \ 
 }
 
 \newcommand{\wIf}[2]{%
-    \mathtt{if} \; {#1} \; \mathtt{then} \; {#2} \; 
+    \mathtt{if} \  {#1} \  \mathtt{then} \  {#2} \ 
 }
 
 \newcommand{\wWhile}[2]{%
-	  \mathtt{while} \; {#1} \; \mathtt{do} \; {#2} \; 
+	  \mathtt{while} \  {#1} \  \mathtt{do} \  {#2} \ 
 }
 
-\newcommand{\wProc}[2]{
-    \mathtt{proc} \; {#1} \; \mathtt{is} \; {#2} \; 
+\newcommand{\wProc}[2]{%
+    \mathtt{proc} \  {#1} \  \mathtt{is} \  {#2} \ 
 }
   
 %%Creates the asignment thing like so; \Assign{x}{a}{s} = s[x |-> A[[a]]s]
 \newcommand{\wAssign}[3]{%
-    {#3}[{#1} \mapsto \mathcal{A}\llbracket {#2} \rrbracket {#3}] 
+    {#3}[{#1} \mapsto \mathcal{A}\llbracket {#2} \rrbracket {#3}]
 }
 
 %Simple shorthand for the semantic arithmetic functions. Saves a lot of space.


### PR DESCRIPTION
The book uses word-spacing in math mode when typesetting the **While** language. This pull request changes the language macros from `\;` (5 mu) to `\ ` (note the trailing space) word-spacing.

I would also drop the extra spacing at the end of each macro in favour of using a combinator (`;`) macro like
```
\newcommand{\comb}{;\ }
```
but I think that would mess with existing usage.